### PR TITLE
staging: prima: Fix non-debug build and switch to it

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_wext.c
@@ -7162,6 +7162,7 @@ static int __iw_get_char_setnone(struct net_device *dev,
    *And currently it only checks P2P_CLIENT adapter.
    *P2P_DEVICE and P2P_GO have not been added as of now.
 */
+#ifdef TRACE_RECORD
         case WE_GET_STATES:
         {
             int buf = 0, len = 0;
@@ -7298,6 +7299,7 @@ static int __iw_get_char_setnone(struct net_device *dev,
             wrqu->data.length = strlen(extra)+1;
             break;
         }
+#endif
 
         case WE_GET_CFG:
         {

--- a/drivers/staging/prima/CORE/MAC/inc/macTrace.h
+++ b/drivers/staging/prima/CORE/MAC/inc/macTrace.h
@@ -43,9 +43,6 @@
 
 #include "aniGlobal.h"
 
-
-#ifdef TRACE_RECORD
-
 #define MAC_TRACE_GET_MODULE_ID(data) ((data >> 8) & 0xff)
 #define MAC_TRACE_GET_MSG_ID(data)       (data & 0xffff)
 
@@ -77,8 +74,6 @@ tANI_U8* macTraceGetcsrRoamSubState(tANI_U16 csrRoamSubState);
 tANI_U8* macTraceGetLimSmeState(tANI_U16 limState);
 tANI_U8* macTraceGetLimMlmState(tANI_U16 mlmState);
 tANI_U8* macTraceGetTLState(tANI_U16 tlState);
-
-#endif
 
 #endif
 

--- a/drivers/staging/prima/CORE/MAC/src/pe/lim/limApi.c
+++ b/drivers/staging/prima/CORE/MAC/src/pe/lim/limApi.c
@@ -1076,8 +1076,8 @@ tSirRetStatus peOpen(tpAniSirGlobal pMac, tMacOpenParameters *pMacOpenParam)
      */
 #ifdef LIM_TRACE_RECORD
     MTRACE(limTraceInit(pMac));
-#endif
     lim_register_debug_callback();
+#endif
     return eSIR_SUCCESS;
 }
 

--- a/drivers/staging/prima/CORE/SME/inc/smsDebug.h
+++ b/drivers/staging/prima/CORE/SME/inc/smsDebug.h
@@ -45,10 +45,15 @@
 #define __printf(a,b)
 #endif
 
+#ifdef WLAN_DEBUG
 void __printf(3,4)
 smsLog(tpAniSirGlobal pMac, tANI_U32 loglevel, const char *pString, ...);
 
 void __printf(3,4)
 pmcLog(tpAniSirGlobal pMac, tANI_U32 loglevel, const char *pString, ...);
+#else
+#define smsLog(arg...)
+#define pmcLog(arg...)
+#endif
 
 #endif // __SMS_DEBUG_H__

--- a/drivers/staging/prima/CORE/SME/src/sme_common/sme_Api.c
+++ b/drivers/staging/prima/CORE/SME/src/sme_common/sme_Api.c
@@ -1540,7 +1540,9 @@ eHalStatus sme_Open(tHalHandle hHal)
 
       sme_p2pOpen(pMac);
       smeTraceInit(pMac);
+#ifdef SME_TRACE_RECORD
       sme_register_debug_callback();
+#endif      
 
    }while (0);
 
@@ -6814,6 +6816,7 @@ VOS_STATUS sme_DbgWriteMemory(tHalHandle hHal, v_U32_t memAddr, v_U8_t *pBuf, v_
 }
 
 
+#ifdef WLAN_DEBUG
 void pmcLog(tpAniSirGlobal pMac, tANI_U32 loglevel, const char *pString, ...)
 {
     VOS_TRACE_LEVEL  vosDebugLevel;
@@ -6834,7 +6837,6 @@ void pmcLog(tpAniSirGlobal pMac, tANI_U32 loglevel, const char *pString, ...)
 
 void smsLog(tpAniSirGlobal pMac, tANI_U32 loglevel, const char *pString,...)
 {
-#ifdef WLAN_DEBUG
     // Verify against current log level
     if ( loglevel > pMac->utils.gLogDbgLevel[LOG_INDEX_FOR_MODULE( SIR_SMS_MODULE_ID )] )
         return;
@@ -6848,8 +6850,8 @@ void smsLog(tpAniSirGlobal pMac, tANI_U32 loglevel, const char *pString,...)
 
         va_end( marker );              /* Reset variable arguments.      */
     }
-#endif
 }
+#endif
 
 /* ---------------------------------------------------------------------------
     \fn sme_GetWcnssWlanCompiledVersion

--- a/drivers/staging/prima/CORE/VOSS/inc/vos_trace.h
+++ b/drivers/staging/prima/CORE/VOSS/inc/vos_trace.h
@@ -113,6 +113,7 @@ typedef enum
 
 #else
 #define MTRACE(p) {  }
+#define CASE_RETURN_STRING( str ) { }
 
 #endif
 

--- a/drivers/staging/prima/Kbuild
+++ b/drivers/staging/prima/Kbuild
@@ -67,7 +67,7 @@ CONFIG_QCOM_ESE_UPLOAD := n
 # Feature flags which are not (currently) configurable via Kconfig
 
 #Whether to build debug version
-BUILD_DEBUG_VERSION := 1
+BUILD_DEBUG_VERSION := 0
 
 #Enable this flag to build driver in diag version
 BUILD_DIAG_VERSION := 1
@@ -706,7 +706,7 @@ CDEFINES += -DEXISTS_MSM_SMSM
 endif
 
 # Fix build for GCC 4.7
-EXTRA_CFLAGS += -Wno-maybe-uninitialized -Wno-unused-function
+EXTRA_CFLAGS += -Wno-maybe-uninitialized -Wno-unused-function -Wno-unused-variable
 
 ifeq ($(CONFIG_WLAN_OFFLOAD_PACKETS),y)
 CDEFINES += -DWLAN_FEATURE_OFFLOAD_PACKETS


### PR DESCRIPTION
Enable the forward declaration of debug functions in non-debug
builds and disable a piece of code used only to print some info.
-Wno-unused-variable is now required because of all the variables
used in debug functions that aren't left out in non-debug builds.

Change-Id: I7069f8859e4965ee82ce65c29c35349c887fd673